### PR TITLE
Add Windows & OSX support for usable_size; fix build

### DIFF
--- a/include/pector/enhanced_allocators.h
+++ b/include/pector/enhanced_allocators.h
@@ -15,6 +15,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#pragma once
 
 #ifndef PECTOR_ENHANCED_ALLOCATORS_H
 #define PECTOR_ENHANCED_ALLOCATORS_H

--- a/include/pector/malloc_allocator.h
+++ b/include/pector/malloc_allocator.h
@@ -34,7 +34,7 @@ struct dummy2 { };
 
 template <class T, bool make_reallocable = true, bool make_size_aware = false>
 struct malloc_allocator: public std::conditional<make_reallocable, reallocable_allocator, internals::dummy1>::type
-#ifdef __GNUC__
+#if defined _WIN32 || defined __GNUC__
 						 , public std::conditional<make_size_aware, size_aware_allocator, internals::dummy2>::type
 #endif
 {
@@ -87,11 +87,16 @@ public:
 
     void destroy(pointer p) { p->~value_type(); }
 
-#ifdef __GNUC__
+#if defined __GNUC__ && !defined _WIN32
 	size_type usable_size(const_pointer p) const
 	{
 		return malloc_usable_size(const_cast<pointer>(p))/sizeof(value_type);
 	}
+#elif defined _WIN32
+    size_type usable_size(const_pointer p) const
+    {
+        return _msize(const_cast<pointer>(p))/sizeof(value_type);
+    }
 #endif
 
 	pointer realloc(pointer p, size_type const n)

--- a/include/pector/pector.h
+++ b/include/pector/pector.h
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#pragma once
+
 #ifndef PECTOR_PECTOR_H
 #define PECTOR_PECTOR_H
 

--- a/include/pector/pector_internals.h
+++ b/include/pector/pector_internals.h
@@ -15,11 +15,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#pragma once
 
 #ifndef PECTOR_INTERNALS_H
 #define PECTOR_INTERNALS_H
 
 #include <algorithm>
+#include <stdexcept>
 
 namespace pt {
 

--- a/include/pector/recommended_size.h
+++ b/include/pector/recommended_size.h
@@ -15,9 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+#pragma once
 
 #ifndef PECTOR_RECOMMENDED_SIZE_H
 #define PECTOR_RECOMMENDED_SIZE_H
+
+#include <algorithm>
 
 namespace pt {
 

--- a/tests/bench.h
+++ b/tests/bench.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PECTOR_BENCH_H
 #define PECTOR_BENCH_H
 

--- a/tests/grow_perfs.cpp
+++ b/tests/grow_perfs.cpp
@@ -28,6 +28,17 @@
 
 #define NRUNS 9
 
+#ifdef _WIN32
+#   warning NOT supported on this platform
+void *malloc_get_state()
+{
+    return nullptr;
+}
+void malloc_set_state(void *)
+{
+}
+#endif
+
 template <class V>
 double one_run(int const N)
 {

--- a/tests/grow_perfs.cpp
+++ b/tests/grow_perfs.cpp
@@ -28,7 +28,7 @@
 
 #define NRUNS 9
 
-#ifdef _WIN32
+#if defined _WIN32 || defined __APPLE__
 #   warning NOT supported on this platform
 void *malloc_get_state()
 {

--- a/tests/types_test.h
+++ b/tests/types_test.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PECTOR_TYPES_TEST_H
 #define PECTOR_TYPES_TEST_H
 


### PR DESCRIPTION
Interesting project. This PR aims for fixing Win/OSX support.
[_msize](https://msdn.microsoft.com/en-us/library/z2s077bc.aspx) is used on Windows and [malloc_size](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/malloc_size.3.html) is used on OSX.
Also add `#pragma once` on every header file by habit:)

Tested platform:
AppleClang, brew g++-4.9.2 on OSX 10.10
MinGW-w64 g++4.9.2 on Windows 7(VM)
